### PR TITLE
Fixed bug - accessing uninitialised variable

### DIFF
--- a/target-version/python/target_version/main.py
+++ b/target-version/python/target_version/main.py
@@ -36,6 +36,7 @@ class CheckAction(Action):
                 return res
 
             for device in iter:
+                version_found = None
                 if device.device_type.ne_type._name == 'cli':
                     version_found = device.platform.version
                 elif 'native' in device.live_status and 'version' in device.live_status.native:


### PR DESCRIPTION
Symptoms - accessing undefined variable or showing version found in previous loop iteration, when not able to determine the software version running on a device.
BTW since we don't have a real junos device I have no code finding the software version in that case.